### PR TITLE
docs: add sprint 5-9 plans and UI screens master

### DIFF
--- a/docs/UI-SCREENS-MASTER.md
+++ b/docs/UI-SCREENS-MASTER.md
@@ -1,0 +1,116 @@
+# UI Screens Master List
+
+Last updated: 2026-02-28
+Purpose: single source of truth for all UI screens across implemented and planned sprints.
+
+## Status Legend
+- **Implemented**: code/route exists now
+- **Planned**: defined in PRD/sprint docs, not fully implemented yet
+- **Future**: roadmap-level screens for scale/enterprise maturity
+
+---
+
+## 1) Core App Screens
+
+### 1.1 Authentication
+- **Auth / Login** — `/auth` — **Implemented**
+
+### 1.2 Onboarding
+- **Merchant Onboarding** — `/onboarding` — **Implemented**
+
+### 1.3 Dashboard
+- **Merchant Dashboard (base)** — `/dashboard` — **Implemented**
+- **Merchant Dashboard (ops KPIs/widgets expanded)** — **Planned** (Sprint 5+)
+
+### 1.4 Menu / Catalog
+- **Menu Management (base)** — `/menu` — **Implemented**
+- **Catalog Management Advanced** (categories, availability windows, sold-out toggle, modifiers) — **Planned** (Sprint 5)
+
+---
+
+## 2) Commerce Experience
+
+### 2.1 Public Ordering
+- **Public Storefront** — **Planned** (Sprint 3)
+- **Cart** — **Planned** (Sprint 3)
+- **Checkout** — **Planned** (Sprint 3)
+- **Payment Status/Result states** — **Planned** (Sprint 3)
+
+### 2.2 Promotions / Growth
+- **Promo/Coupon Management** — **Planned** (Sprint 6)
+- **Checkout Promo Validation UX** — **Planned** (Sprint 6)
+- **Repeat Order UX** (quick reorder/recent/favorites) — **Planned** (Sprint 8)
+
+---
+
+## 3) Operations Screens
+
+### 3.1 Staff Operations
+- **Staff Order Board (baseline)** — **Planned** (Sprint 3)
+- **Staff Board Advanced** (filters/search/queue prioritization) — **Planned** (Sprint 5)
+
+### 3.2 Notifications / Engagement
+- **Order Event Templates / Communication controls** — **Planned** (Sprint 6)
+- **Notification Delivery Status / Logs (UI)** — **Planned** (Sprint 6)
+
+---
+
+## 4) Analytics & Insights
+
+- **Funnel Analytics Dashboard** (view → cart → checkout → payment success) — **Planned** (Sprint 6)
+- **Tenant Health Overview Dashboard** — **Planned** (Sprint 6/9)
+- **Merchant Insights Dashboard** (top-selling, peak windows, cancellation causes) — **Planned** (Sprint 8)
+- **Action Center / Recommendations** — **Planned** (Sprint 8)
+- **Weekly Summary / Report View** — **Planned** (Sprint 8)
+
+---
+
+## 5) Admin, Governance, Enterprise Screens
+
+- **Tenant Admin Console** (tenant lifecycle, plan states, limits) — **Planned** (Sprint 9)
+- **Governance / Role Matrix Admin** — **Planned** (Sprint 9)
+- **Audit Export / Compliance Reports UI** — **Planned** (Sprint 9)
+- **Support Diagnostics Bundle UI** — **Planned** (Sprint 9)
+- **Integrations Management** (adapter status/sync/reconciliation) — **Planned** (Sprint 9)
+
+---
+
+## 6) Suggested Navigation Map (Target)
+
+1. Auth
+2. Onboarding
+3. Dashboard
+4. Menu/Catalog
+5. Storefront (public)
+6. Checkout
+7. Staff Board
+8. Promotions
+9. Analytics/Insights
+10. Tenant Admin
+11. Integrations
+12. Support Diagnostics
+
+---
+
+## 7) Source References
+- `docs/prds/PRD-001-merchant-onboarding-and-storefront-mvp.md`
+- `docs/prds/SPRINT-1-PLAN.md`
+- `docs/prds/SPRINT-2-PLAN.md`
+- `docs/prds/SPRINT-3-PLAN.md`
+- `docs/prds/SPRINT-5-PLAN.md`
+- `docs/prds/SPRINT-6-PLAN.md`
+- `docs/prds/SPRINT-7-PLAN.md`
+- `docs/prds/SPRINT-8-PLAN.md`
+- `docs/prds/SPRINT-9-PLAN.md`
+- `frontend/src/app/app.routes.ts`
+
+---
+
+## 8) Quick Current Reality Snapshot
+Currently code-implemented routes:
+- `/auth`
+- `/onboarding`
+- `/dashboard`
+- `/menu`
+
+All other screens above are planned roadmap items and should be promoted to implementation via sprint-linked issues.

--- a/docs/prds/SPRINT-5-PLAN.md
+++ b/docs/prds/SPRINT-5-PLAN.md
@@ -1,0 +1,49 @@
+# Sprint 5 Plan (2 weeks)
+
+## Goal
+Scale merchant operations capabilities: catalog quality, fulfillment operations, and reliability guardrails for growing order volume.
+
+## Objectives
+1. Complete robust menu/catalog management (categories, availability windows, modifiers baseline)
+2. Strengthen order operations tooling for merchants/staff
+3. Add reliability controls (timeouts, retries, dead-letter/error handling)
+4. Introduce operational dashboards for merchant health
+
+## Scope (Committed)
+### Product / UX
+- Menu enhancements: categories, item availability, sold-out toggle, basic modifiers
+- Staff board improvements: filtering, search, queue prioritization, status timestamps
+- Merchant dashboard widgets: order volume, completion rate, cancellation trend
+
+### Backend / Platform
+- Expand order APIs for operational filters and pagination
+- Add background job retry policy + failure logging conventions
+- Add audit trail entries for order/status/payment events
+- Harden webhook handling and error recovery paths
+
+### Quality / Documentation
+- Integration tests for menu availability and modifier logic
+- Ops runbook update for common incident patterns
+- API docs alignment for new catalog/ops endpoints
+
+## Out of Scope
+- Advanced loyalty/referral programs
+- Multi-brand white-label customization
+- Predictive demand forecasting
+
+## Definition of Done
+- Merchant can manage richer catalog states without breaking checkout
+- Staff can operate high-volume queues with filter/search support
+- Operational metrics visible from dashboard baseline
+- Retry/failure patterns are observable and documented
+
+## Suggested Issues
+- Catalog enhancements (availability + modifiers)
+- Staff board operational UX improvements
+- Order ops API filters + pagination
+- Audit trail + reliability policy hardening
+
+## Acceptance Metrics
+- <1% order processing failures caused by transient errors in test runs
+- 100% status changes write audit events
+- Operational dashboard data consistent with API counts

--- a/docs/prds/SPRINT-6-PLAN.md
+++ b/docs/prds/SPRINT-6-PLAN.md
@@ -1,0 +1,48 @@
+# Sprint 6 Plan (2 weeks)
+
+## Goal
+Expand growth and merchant-business tooling: promotions baseline, customer engagement hooks, and analytics maturity.
+
+## Objectives
+1. Launch promotions/coupons baseline for checkout
+2. Add customer communication events (order confirmations/status updates)
+3. Build conversion funnel and retention analytics views
+4. Improve admin visibility across tenant performance
+
+## Scope (Committed)
+### Growth Features
+- Coupon model: fixed/percent discount with constraints (expiry, usage limits)
+- Checkout integration for promo code validation and discount application
+- Promotion performance metrics (usage, conversion impact)
+
+### Customer Engagement
+- Event templates for order created/paid/ready/completed
+- Notification pipeline abstraction (email/SMS adapter-ready)
+- Delivery status logging for communication events
+
+### Analytics / Admin
+- Funnel metrics: storefront views -> cart -> checkout start -> payment success
+- Tenant health overview: revenue, failed payments, cancellation rates
+- Export-ready reporting endpoints for weekly business review
+
+## Out of Scope
+- Full CRM lifecycle automation
+- AI recommendation engine
+- Multi-channel marketing orchestration
+
+## Definition of Done
+- Promo codes apply correctly with edge-case validation
+- Customer notification events fire for core order lifecycle stages
+- Funnel and tenant KPI dashboards available for review
+- Data definitions are documented and reproducible
+
+## Suggested Issues
+- Promotions and coupon engine baseline
+- Notification event pipeline + templates
+- Funnel analytics dashboards + reporting endpoints
+- Tenant health admin panel metrics
+
+## Acceptance Metrics
+- Promo calculation parity in API + UI (no mismatch defects)
+- Notification delivery events logged for 95%+ test flows
+- Funnel dashboard reflects end-to-end test traffic accurately

--- a/docs/prds/SPRINT-7-PLAN.md
+++ b/docs/prds/SPRINT-7-PLAN.md
@@ -1,0 +1,49 @@
+# Sprint 7 Plan (2 weeks)
+
+## Goal
+Finalize launch candidate: enterprise-grade security/compliance posture, performance optimization, and handoff-ready platform operations.
+
+## Objectives
+1. Complete launch hardening across security, performance, and reliability
+2. Prepare platform for multi-tenant scale readiness checks
+3. Finalize documentation/runbooks for autonomous AI + human operations
+4. Execute release-candidate validation and go-live checklist
+
+## Scope (Committed)
+### Security / Compliance
+- Security review pass: auth/RBAC, tenant boundary penetration checks, secret handling
+- Dependency and vulnerability scan remediation
+- Audit log completeness and retention policy documentation
+
+### Performance / Reliability
+- Load-test core flows (menu browse, checkout, order updates)
+- Query/index optimization for hot paths
+- Caching strategy baseline for read-heavy endpoints
+- SLO definitions and alert thresholds
+
+### Operations / Handoff
+- Final runbooks: deploy, rollback, incident response, data restore drill
+- Full AI handoff pack update (architecture + sprint status + known risks)
+- Versioned release notes and migration notes
+
+## Out of Scope
+- New feature modules that expand product surface area
+- Non-critical design overhauls
+
+## Definition of Done
+- Security checklist complete with no open critical findings
+- Performance targets met for core journeys
+- Release candidate passes smoke/regression suites
+- Operational docs are complete enough for independent execution
+
+## Suggested Issues
+- Security hardening + vulnerability remediation
+- Performance/load benchmark optimization
+- SLO/alerts and observability baseline finalization
+- Release-candidate QA and go-live playbook
+
+## Acceptance Metrics
+- 0 critical security findings open
+- p95 latency targets met on core endpoints under expected load
+- RC pass rate >= agreed threshold across regression suite
+- Successful dry-run for rollback and incident response

--- a/docs/prds/SPRINT-8-PLAN.md
+++ b/docs/prds/SPRINT-8-PLAN.md
@@ -1,0 +1,51 @@
+# Sprint 8 Plan (2 weeks)
+
+## Goal
+Drive post-launch optimization: growth loops, merchant retention tooling, and platform cost/performance efficiency.
+
+## Objectives
+1. Improve conversion and repeat-order behavior with targeted product optimizations
+2. Add merchant retention tools (insights + actionable recommendations)
+3. Optimize infra/runtime cost without degrading reliability
+4. Strengthen experimentation framework for data-driven iteration
+
+## Scope (Committed)
+### Growth / Product
+- A/B experiment framework baseline for key checkout and menu UX variants
+- Repeat-order UX (quick reorder, recent items, favorites baseline)
+- Promo optimization rules (time-bound and segment-bound application)
+
+### Merchant Retention
+- Merchant insights dashboard: top-selling items, peak order windows, cancellation root causes
+- Action center recommendations (e.g., low-conversion menu items, unavailable best-sellers)
+- Weekly merchant summary report endpoint
+
+### Platform Efficiency
+- Cost observability for API/background jobs/realtime workloads
+- Optimize expensive queries and background tasks
+- Caching and TTL strategy refinements for read-heavy endpoints
+
+### Quality / Governance
+- Experiment result logging and decision documentation template
+- KPI definitions updated for growth + retention metrics
+
+## Out of Scope
+- Full ML personalization engine
+- International expansion/localization tracks
+
+## Definition of Done
+- At least one A/B experiment runs end-to-end with measurable result capture
+- Merchant insights and action recommendations are available in dashboard baseline
+- Cost/performance report shows concrete optimization impact
+- Team has repeatable experiment + analysis workflow
+
+## Suggested Issues
+- Experimentation framework + assignment logic
+- Repeat-order UX baseline
+- Merchant insights and action center
+- Cost observability and optimization pass
+
+## Acceptance Metrics
+- Improvement in checkout completion or reorder proxy metric in experiment data
+- Merchant insights match source-of-truth operational data
+- Measurable reduction in selected infra/API cost hotspots

--- a/docs/prds/SPRINT-9-PLAN.md
+++ b/docs/prds/SPRINT-9-PLAN.md
@@ -1,0 +1,52 @@
+# Sprint 9 Plan (2 weeks)
+
+## Goal
+Enterprise readiness and expansion baseline: governance, integrations, and scalable multi-tenant operations.
+
+## Objectives
+1. Prepare platform for larger tenant portfolios and stricter governance expectations
+2. Add integration readiness for external systems (accounting/POS/ERP adapters baseline)
+3. Mature tenant administration and support tooling
+4. Formalize long-term maintenance and upgrade strategy
+
+## Scope (Committed)
+### Governance / Admin
+- Tenant admin console enhancements (tenant lifecycle controls, plan states, limits)
+- Role matrix review and least-privilege policy verification
+- Audit/report exports for compliance and support operations
+
+### Integrations
+- External integration abstraction layer (provider adapters)
+- First adapter baseline (e.g., accounting export or POS sync draft)
+- Retry/backoff and reconciliation flow for failed sync events
+
+### Operations at Scale
+- Multi-tenant health dashboard and alert routing by severity
+- Support tooling: tenant-scoped diagnostics bundle
+- Data migration/versioning strategy for iterative schema evolution
+
+### Platform Lifecycle
+- Versioned API deprecation policy draft
+- Upgrade runbook and backward-compatibility checklist
+- Quarterly technical debt framework proposal
+
+## Out of Scope
+- Full enterprise SSO rollout (unless required for pilot tenant)
+- Deep custom integration per enterprise client
+
+## Definition of Done
+- Admin + governance controls support managed scale operations
+- At least one integration path works with reconciliation safety
+- Tenant diagnostics flow accelerates support troubleshooting
+- Versioning/deprecation/upgrade policies are documented and actionable
+
+## Suggested Issues
+- Tenant governance and admin controls
+- Integration adapter baseline + reconciliation
+- Support diagnostics and multi-tenant health tooling
+- API lifecycle and upgrade governance docs
+
+## Acceptance Metrics
+- Reduced support triage time using diagnostics bundle
+- Integration sync reliability baseline established in test scenarios
+- Governance/audit exports validated for support/compliance use


### PR DESCRIPTION
## Summary
- add `docs/prds/SPRINT-5-PLAN.md`
- add `docs/prds/SPRINT-6-PLAN.md`
- add `docs/prds/SPRINT-7-PLAN.md`
- add `docs/prds/SPRINT-8-PLAN.md`
- add `docs/prds/SPRINT-9-PLAN.md`
- add `docs/UI-SCREENS-MASTER.md` (single consolidated UI screen index)

## Linked Issues
Closes #30
Refs #31
Refs #32
Refs #33
Refs #34

## Notes
Documentation-only roadmap/planning update.
