### PR TITLE
docs: add staff onboarding/login and admin-staff RBAC to sprint plan

### DIFF
--- a/docs/UI-SCREENS-MASTER.md
+++ b/docs/UI-SCREENS-MASTER.md
@@ -13,10 +13,13 @@ Purpose: single source of truth for all UI screens across implemented and planne
 ## 1) Core App Screens
 
 ### 1.1 Authentication
-- **Auth / Login** — `/auth` — **Implemented**
+- **Auth / Login (Admin)** — `/auth` — **Implemented**
+- **Staff Login** — **Planned** (Sprint 3)
+- **Role-based Access Entry (Admin vs Staff)** — **Planned** (Sprint 3)
 
 ### 1.2 Onboarding
 - **Merchant Onboarding** — `/onboarding` — **Implemented**
+- **Staff Onboarding / Invite Flow** — **Planned** (Sprint 3)
 
 ### 1.3 Dashboard
 - **Merchant Dashboard (base)** — `/dashboard` — **Implemented**
@@ -67,6 +70,7 @@ Purpose: single source of truth for all UI screens across implemented and planne
 
 ## 5) Admin, Governance, Enterprise Screens
 
+- **Staff Management & Authorization Screen** (invite staff, assign/revoke roles/permissions) — **Planned** (Sprint 3)
 - **Tenant Admin Console** (tenant lifecycle, plan states, limits) — **Planned** (Sprint 9)
 - **Governance / Role Matrix Admin** — **Planned** (Sprint 9)
 - **Audit Export / Compliance Reports UI** — **Planned** (Sprint 9)

--- a/docs/prds/SPRINT-3-PLAN.md
+++ b/docs/prds/SPRINT-3-PLAN.md
@@ -10,8 +10,10 @@ After Sprint 2 hardens tenant-safe onboarding + menu core, Sprint 3 unlocks busi
 1. Public storefront -> checkout journey is functional
 2. Stripe Connect + PaymentIntent flow integrated (sandbox)
 3. Order lifecycle state machine implemented with transition guards
-4. Staff board receives near-realtime order updates via SignalR baseline
-5. Payment/order consistency safeguards added (idempotency + retry handling)
+4. Staff onboarding + staff login flow delivered
+5. Admin vs Staff authorization boundaries enforced (RBAC baseline)
+6. Staff board receives near-realtime order updates via SignalR baseline
+7. Payment/order consistency safeguards added (idempotency + retry handling)
 
 ## Scope (Committed)
 ### Checkout + Storefront
@@ -24,6 +26,12 @@ After Sprint 2 hardens tenant-safe onboarding + menu core, Sprint 3 unlocks busi
 - Create PaymentIntent server-side with tenant/store context
 - Handle payment success/failure/cancel callbacks
 - Add idempotency key strategy for payment/order endpoints
+
+### Staff Access + Authorization
+- Implement staff onboarding flow (invite/add staff by admin)
+- Implement staff login flow and session handling
+- Introduce RBAC baseline with separate permissions for Admin vs Staff
+- Enforce route/API guards so staff can access operational views only
 
 ### Order Domain + Realtime
 - Implement order state machine (e.g., Created -> Paid -> Preparing -> Ready -> Completed; Cancelled paths)
@@ -44,21 +52,25 @@ After Sprint 2 hardens tenant-safe onboarding + menu core, Sprint 3 unlocks busi
 ## Linked Issues (Execution Map)
 - #4 Stripe Connect onboarding + payment intent flow
 - #5 Order lifecycle state machine + SignalR updates
-- Follow-up issue creation recommended: "Storefront + checkout UI integration"
+- #36 Staff onboarding + staff login + admin/staff RBAC baseline
 
 ## Definition of Done
 - Sandbox paid order can be completed end-to-end
+- Staff onboarding and login work end-to-end
+- Admin and Staff permission boundaries are enforced at UI + API levels
 - Duplicate payment callback does not create duplicate orders
 - Order transitions are validated and reject invalid state jumps
 - Staff board reflects status changes in near-realtime
 - API docs match implemented checkout/payment/order behavior
 
 ## Demo Script (End of Sprint)
-1. Merchant has published menu from prior sprint
-2. Customer adds items on storefront and proceeds to checkout
-3. PaymentIntent created and completed in sandbox
-4. Order appears on staff board and transitions through statuses
-5. Show failure/retry case and confirm no duplicate order creation
+1. Admin invites/onboards a staff member
+2. Staff logs in and lands on authorized operational views
+3. Merchant has published menu from prior sprint
+4. Customer adds items on storefront and proceeds to checkout
+5. PaymentIntent created and completed in sandbox
+6. Order appears on staff board and transitions through statuses
+7. Show failure/retry case and confirm no duplicate order creation
 
 ## Risks
 1. Payment/order race conditions causing inconsistent states


### PR DESCRIPTION
## Summary
- update `docs/prds/SPRINT-3-PLAN.md` to include:
  - staff onboarding/invite flow
  - staff login flow
  - admin vs staff RBAC boundaries
- update `docs/UI-SCREENS-MASTER.md` to include staff auth/onboarding/authorization screens

## Linked Issues
Closes #36

## Notes
Documentation/planning update to make staff auth scope explicit in sprint and UI map.
